### PR TITLE
Lineup Styling Customisation

### DIFF
--- a/public/js/lineupPoster.js
+++ b/public/js/lineupPoster.js
@@ -1,6 +1,43 @@
 const poster = document.querySelector("#poster");
 const output = document.querySelector("#output");
 const downloadButton = document.querySelector("#poster-download");
+const selectPosterBackground = document.querySelector("#poster-background");
+const selectPosterText = document.querySelector("#poster-text");
+
+const colours = [
+    "white",
+    "black",
+    "red",
+    "green",
+    "blue",
+    "orange",
+    "purple",
+    "pink"
+];
+
+selectPosterBackground.addEventListener("change", ({ target }) => {
+    const { value } = target;
+
+    colours.forEach((colour) => {
+        if (poster.classList.contains(`poster-background-${colour}`)) {
+            poster.classList.remove(`poster-background-${colour}`);
+        }
+    });
+
+    poster.classList.add(`poster-background-${value}`);
+});
+
+selectPosterText.addEventListener("change", ({ target }) => {
+    const { value } = target;
+
+    colours.forEach((colour) => {
+        if (poster.classList.contains(`poster-text-${colour}`)) {
+            poster.classList.remove(`poster-text-${colour}`);
+        }
+    });
+
+    poster.classList.add(`poster-text-${value}`);
+});
 
 downloadButton.addEventListener("click", async () => {
     const canvas = await html2canvas(poster);
@@ -8,4 +45,5 @@ downloadButton.addEventListener("click", async () => {
 
     window.open(img);
 });
+
 (async () => output.append(await html2canvas(poster)))();

--- a/public/js/lineupPoster.js
+++ b/public/js/lineupPoster.js
@@ -3,6 +3,8 @@ const output = document.querySelector("#output");
 const downloadButton = document.querySelector("#poster-download");
 const selectPosterBackground = document.querySelector("#poster-background");
 const selectPosterText = document.querySelector("#poster-text");
+const selectItalicFont = document.querySelector("#poster-font-italic");
+const selectUnderlinedFont = document.querySelector("#poster-font-underlined");
 
 const colours = [
     "white",
@@ -37,6 +39,26 @@ selectPosterText.addEventListener("change", ({ target }) => {
     });
 
     poster.classList.add(`poster-text-${value}`);
+});
+
+selectItalicFont.addEventListener("change", ({ target }) => {
+    const { checked } = target;
+
+    if (!checked) {
+        poster.classList.remove("poster-font-italic");
+    } else {
+        poster.classList.add("poster-font-italic");
+    }
+});
+
+selectUnderlinedFont.addEventListener("change", ({ target }) => {
+    const { checked } = target;
+
+    if (!checked) {
+        poster.classList.remove("poster-font-underlined");
+    } else {
+        poster.classList.add("poster-font-underlined");
+    }
 });
 
 downloadButton.addEventListener("click", async () => {

--- a/public/scss/lineup-poster.scss
+++ b/public/scss/lineup-poster.scss
@@ -107,3 +107,11 @@
 .poster-text-pink {
   color: #FF00FB;
 }
+
+.poster-font-italic {
+  font-style: italic;
+}
+
+.poster-font-underlined {
+  text-decoration: underline;
+}

--- a/public/scss/lineup-poster.scss
+++ b/public/scss/lineup-poster.scss
@@ -15,7 +15,7 @@
   }
 
   h2 {
-    font-size: 2rem;
+    font-size: 2.75rem;
   }
 
   h3 {
@@ -42,4 +42,68 @@
 #download-area {
   padding: 50px;
   text-align: center;
+}
+
+.poster-background-white {
+  background-color: #FFFFFF;
+}
+
+.poster-background-black {
+  background-color: #000000;
+}
+
+.poster-background-red {
+  background-color: #FF0000;
+}
+
+.poster-background-green {
+  background-color: #00FF00;
+}
+
+.poster-background-blue {
+  background-color: #0000FF;
+}
+
+.poster-background-orange {
+  background-color: #FF3A00;
+}
+
+.poster-background-purple {
+  background-color: #A500FF;
+}
+
+.poster-background-pink {
+  background-color: #FF00FB;
+}
+
+.poster-text-white {
+  color: #FFFFFF;
+}
+
+.poster-text-black {
+  color: #000000;
+}
+
+.poster-text-red {
+  color: #FF0000;
+}
+
+.poster-text-green {
+  color: #00FF00;
+}
+
+.poster-text-blue {
+  color: #0000FF;
+}
+
+.poster-text-orange {
+  color: #FF3A00;
+}
+
+.poster-text-purple {
+  color: #A500FF;
+}
+
+.poster-text-pink {
+  color: #FF00FB;
 }

--- a/src/services/SpotifyService.ts
+++ b/src/services/SpotifyService.ts
@@ -141,8 +141,6 @@ class SpotifyService {
 			}
 		});
 
-		console.log(items);
-
 		return items.map((artist: any) => ({
 			name: artist.name
 		}));

--- a/views/lineup-poster.ejs
+++ b/views/lineup-poster.ejs
@@ -13,6 +13,32 @@
                 <h1>
                     Customise Your Poster
                 </h1>
+                <label>
+                    Background Colour
+                    <select id="poster-background">
+                        <option value="white">White</option>
+                        <option value="black">Black</option>
+                        <option value="red">Red</option>
+                        <option value="blue">Blue</option>
+                        <option value="green">Green</option>
+                        <option value="orange">Orange</option>
+                        <option value="purple">Purple</option>
+                        <option value="pink">Pink</option>
+                    </select>
+                </label>
+                <label>
+                    Font Colour
+                    <select id="poster-text">
+                        <option value="white">White</option>
+                        <option selected value="black">Black</option>
+                        <option value="red">Red</option>
+                        <option value="blue">Blue</option>
+                        <option value="green">Green</option>
+                        <option value="orange">Orange</option>
+                        <option value="purple">Purple</option>
+                        <option value="pink">Pink</option>
+                    </select>
+                </label>
             </section>
             <section id="poster">
                 <h1>

--- a/views/lineup-poster.ejs
+++ b/views/lineup-poster.ejs
@@ -13,32 +13,44 @@
                 <h1>
                     Customise Your Poster
                 </h1>
-                <label>
-                    Background Colour
-                    <select id="poster-background">
-                        <option value="white">White</option>
-                        <option value="black">Black</option>
-                        <option value="red">Red</option>
-                        <option value="blue">Blue</option>
-                        <option value="green">Green</option>
-                        <option value="orange">Orange</option>
-                        <option value="purple">Purple</option>
-                        <option value="pink">Pink</option>
-                    </select>
-                </label>
-                <label>
-                    Font Colour
-                    <select id="poster-text">
-                        <option value="white">White</option>
-                        <option selected value="black">Black</option>
-                        <option value="red">Red</option>
-                        <option value="blue">Blue</option>
-                        <option value="green">Green</option>
-                        <option value="orange">Orange</option>
-                        <option value="purple">Purple</option>
-                        <option value="pink">Pink</option>
-                    </select>
-                </label>
+                <div class="poster-options">
+                    <label>
+                        Background Colour
+                        <select id="poster-background">
+                            <option value="white">White</option>
+                            <option value="black">Black</option>
+                            <option value="red">Red</option>
+                            <option value="blue">Blue</option>
+                            <option value="green">Green</option>
+                            <option value="orange">Orange</option>
+                            <option value="purple">Purple</option>
+                            <option value="pink">Pink</option>
+                        </select>
+                    </label>
+                    <label>
+                        Font Colour
+                        <select id="poster-text">
+                            <option value="white">White</option>
+                            <option selected value="black">Black</option>
+                            <option value="red">Red</option>
+                            <option value="blue">Blue</option>
+                            <option value="green">Green</option>
+                            <option value="orange">Orange</option>
+                            <option value="purple">Purple</option>
+                            <option value="pink">Pink</option>
+                        </select>
+                    </label>
+                </div>
+                <div class="poster-options">
+                    <label>
+                        Italic Font
+                        <input id="poster-font-italic" type="checkbox" />
+                    </label>
+                    <label>
+                        Underlined Font
+                        <input id="poster-font-underlined" type="checkbox" />
+                    </label>
+                </div>
             </section>
             <section id="poster">
                 <h1>


### PR DESCRIPTION
 Allows the user to customise the styling of their lineup poster.

#### Overview
- Added custom poster background colour support
- Added custom poster font colour support
- Added support to toggle between italic font on and off on the poster
- Added support to toggle between underlined font on and off on the poster
- Removed useless `console.log()` in `SpotifyService`